### PR TITLE
fix: Pad target region by `max_amplicon_length`

### DIFF
--- a/prymer/primer3/primer3.py
+++ b/prymer/primer3/primer3.py
@@ -79,8 +79,8 @@ In this case, there are two failures reasons:
 ```python
 >>> for failure in left_result.failures: \
     print(failure)
-Primer3Failure(reason=<Primer3FailureReason.HIGH_TM: 'high tm'>, count=171)
-Primer3Failure(reason=<Primer3FailureReason.GC_CONTENT: 'GC content failed'>, count=26)
+Primer3Failure(reason=<Primer3FailureReason.HIGH_TM: 'high tm'>, count=406)
+Primer3Failure(reason=<Primer3FailureReason.GC_CONTENT: 'GC content failed'>, count=91)
 
 ```
 

--- a/prymer/primer3/primer3_parameters.py
+++ b/prymer/primer3/primer3_parameters.py
@@ -140,3 +140,8 @@ class Primer3Parameters:
     def max_primer_length(self) -> int:
         """Max primer length"""
         return int(self.primer_sizes.max)
+
+    @property
+    def min_primer_length(self) -> int:
+        """Minimum primer length."""
+        return int(self.primer_sizes.min)

--- a/tests/primer3/test_primer3.py
+++ b/tests/primer3/test_primer3.py
@@ -558,7 +558,7 @@ def test_primer3_result_as_primer_pair_result_exception(
 
 
 @pytest.mark.parametrize("max_amplicon_length", [100, 101])
-def test_pad_target_region(max_amplicon_length: int, genome_ref: Path) -> None:
+def test_create_design_region(max_amplicon_length: int, genome_ref: Path) -> None:
     """If the target region is shorter than the max amplicon length, it should be padded to fit."""
     target_region = Span(refname="chr1", start=201, end=250, strand=Strand.POSITIVE)
 
@@ -572,12 +572,34 @@ def test_pad_target_region(max_amplicon_length: int, genome_ref: Path) -> None:
     assert design_region.length == 2 * max_amplicon_length - target_region.length
 
 
-def test_pad_target_region_doesnt_pad(genome_ref: Path) -> None:
-    """If the target region is larger than the max amplicon length, no padding should occur."""
+def test_create_design_region_raises_when_target_region_exceeds_max_amplicon_length(
+    genome_ref: Path,
+) -> None:
+    """
+    `_create_design_region()` should raise a ValueError when the target region is larger than the
+    max amplicon length.
+    """
     target_region = Span(refname="chr1", start=201, end=250, strand=Strand.POSITIVE)
 
     with Primer3(genome_fasta=genome_ref) as designer:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="exceeds the maximum size"):
             designer._create_design_region(
                 target_region=target_region, max_amplicon_length=10, min_primer_length=10
+            )
+
+
+def test_create_design_region_raises_when_primers_would_not_fit_in_design_region(
+    genome_ref: Path,
+) -> None:
+    """
+    `_create_design_region()` should raise a ValueError when the design region does not include
+    sufficient space flanking the target for a primer to be designed. (i.e. when this space is less
+    than the specified minimum primer length.)
+    """
+    target_region = Span(refname="chr1", start=201, end=250, strand=Strand.POSITIVE)
+
+    with Primer3(genome_fasta=genome_ref) as designer:
+        with pytest.raises(ValueError, match="exceeds the maximum size"):
+            designer._create_design_region(
+                target_region=target_region, max_amplicon_length=55, min_primer_length=10
             )

--- a/tests/primer3/test_primer3.py
+++ b/tests/primer3/test_primer3.py
@@ -563,11 +563,13 @@ def test_pad_target_region(max_amplicon_length: int, genome_ref: Path) -> None:
     target = Span(refname="chr1", start=201, end=250, strand=Strand.POSITIVE)
 
     with Primer3(genome_fasta=genome_ref) as designer:
-        padded_region: Span = designer._pad_target_region(
-            target=target, max_amplicon_length=max_amplicon_length
+        design_region: Span = designer._create_design_region(
+            target=target,
+            max_amplicon_length=max_amplicon_length,
+            min_primer_length=10,
         )
 
-    assert padded_region.length == max_amplicon_length
+    assert design_region.length == 2 * max_amplicon_length - target.length
 
 
 def test_pad_target_region_doesnt_pad(genome_ref: Path) -> None:
@@ -575,6 +577,7 @@ def test_pad_target_region_doesnt_pad(genome_ref: Path) -> None:
     target = Span(refname="chr1", start=201, end=250, strand=Strand.POSITIVE)
 
     with Primer3(genome_fasta=genome_ref) as designer:
-        padded_region: Span = designer._pad_target_region(target=target, max_amplicon_length=10)
-
-    assert padded_region == target
+        with pytest.raises(ValueError):
+            designer._create_design_region(
+                target=target, max_amplicon_length=10, min_primer_length=10
+            )

--- a/tests/primer3/test_primer3.py
+++ b/tests/primer3/test_primer3.py
@@ -560,24 +560,24 @@ def test_primer3_result_as_primer_pair_result_exception(
 @pytest.mark.parametrize("max_amplicon_length", [100, 101])
 def test_pad_target_region(max_amplicon_length: int, genome_ref: Path) -> None:
     """If the target region is shorter than the max amplicon length, it should be padded to fit."""
-    target = Span(refname="chr1", start=201, end=250, strand=Strand.POSITIVE)
+    target_region = Span(refname="chr1", start=201, end=250, strand=Strand.POSITIVE)
 
     with Primer3(genome_fasta=genome_ref) as designer:
         design_region: Span = designer._create_design_region(
-            target=target,
+            target_region=target_region,
             max_amplicon_length=max_amplicon_length,
             min_primer_length=10,
         )
 
-    assert design_region.length == 2 * max_amplicon_length - target.length
+    assert design_region.length == 2 * max_amplicon_length - target_region.length
 
 
 def test_pad_target_region_doesnt_pad(genome_ref: Path) -> None:
     """If the target region is larger than the max amplicon length, no padding should occur."""
-    target = Span(refname="chr1", start=201, end=250, strand=Strand.POSITIVE)
+    target_region = Span(refname="chr1", start=201, end=250, strand=Strand.POSITIVE)
 
     with Primer3(genome_fasta=genome_ref) as designer:
         with pytest.raises(ValueError):
             designer._create_design_region(
-                target=target, max_amplicon_length=10, min_primer_length=10
+                target_region=target_region, max_amplicon_length=10, min_primer_length=10
             )


### PR DESCRIPTION
Closes #16 
Closes #17 

This PR fixes the padding of the target region to be consistent with the original `fgprimer` implementation. (My bad 🙃 )

https://github.com/fulcrumgenomics/fgprimer/blob/6cf2542e927ced37dd0dce4c335de8dff07789c7/src/main/scala/com/fulcrumgenomics/primerdesign/primer3/Primer3.scala#L89-L93

Other changes
- Validate that the max amplicon length permits sufficient space around the target region for primers to be designed
- Renamed `region` to `design_region`, to better reflect the target/design region distinction
- Renamed `_pad_target_region` to `_create_design_region`, for the same reason, and clarified its documentation
- Added `min_primer_length` property to `Primer3Parameters` (`max_primer_length` already existed)
