### PR TITLE
fix: Executable path validation tests should not be dependent on the user environment

### DIFF
--- a/tests/util/test_executable_runner.py
+++ b/tests/util/test_executable_runner.py
@@ -41,8 +41,8 @@ def test_validate_executable_path_not_executable() -> None:
 def test_validate_executable_path(tmp_path: Path) -> None:
     """
     `validate_executable_path` should return the `yes` executable in the following scenarios:
-    1. When the name of the executable is passed as a string.
-    2. When the absolute path to the executable is passed, either as a string or a Path.
+    1. The name of the executable is passed as a string, and the executable is on the user's PATH.
+    2. The absolute path to the executable is passed, either as a string or a Path.
     """
     expected_path = tmp_path / "yes"
     expected_path.touch()  # create the file

--- a/tests/util/test_executable_runner.py
+++ b/tests/util/test_executable_runner.py
@@ -30,12 +30,11 @@ def test_validate_executable_path_not_executable() -> None:
             ExecutableRunner.validate_executable_path(executable=tmpfile.name)
 
 
-@pytest.mark.parametrize("executable", ["yes", "/usr/bin/yes", Path("/usr/bin/yes")])
-def test_validate_executable_path(executable: str | Path) -> None:
+@pytest.mark.parametrize("executable", ["/usr/bin/yes", Path("/usr/bin/yes")])
+def test_validate_executable_path_returns_existing_paths(executable: str | Path) -> None:
     """
-    `validate_executable_path` should find the `yes` executable in the following scenarios:
-    1. when the string "yes" is passed
-    2. when the absolute path to the `yes` executable is passed, either as a string or a Path
+    `validate_executable_path` should return the `yes` executable when the absolute path to the
+    executable is passed, either as a string or a Path.
     """
     expected_path: Path = Path("/usr/bin/yes")
 
@@ -44,6 +43,18 @@ def test_validate_executable_path(executable: str | Path) -> None:
         os.environ.pop("PATH")
 
         validated_path: Path = ExecutableRunner.validate_executable_path(executable=executable)
+        assert validated_path == expected_path
+
+
+def test_validate_executable_finds_on_path() -> None:
+    """
+    `validate_executable_path` should find executables on the PATH when the name of the executable
+    is passed as a string.
+    """
+    expected_path: Path = Path("/usr/bin/yes")
+
+    with mock.patch("shutil.which", return_value=expected_path.as_posix()):
+        validated_path: Path = ExecutableRunner.validate_executable_path(executable="yes")
         assert validated_path == expected_path
 
 

--- a/tests/util/test_executable_runner.py
+++ b/tests/util/test_executable_runner.py
@@ -45,10 +45,10 @@ def test_validate_executable_path(tmp_path: Path) -> None:
     2. The absolute path to the executable is passed, either as a string or a Path.
     """
     expected_path = tmp_path / "yes"
-    expected_path.touch()  # create the file
-    expected_path.chmod(755)  # make it executable
+    expected_path.touch()
+    expected_path.chmod(755)
 
-    # Clear the PATH, in case the user has a local version of `yes` elsewhere on their PATH
+    # Clear the PATH, to override any local versions of `yes` on the user's PATH
     with mock.patch.dict(os.environ, clear=True):
         os.environ["PATH"] = str(tmp_path)
 

--- a/tests/util/test_executable_runner.py
+++ b/tests/util/test_executable_runner.py
@@ -19,12 +19,20 @@ def test_close_twice() -> None:
     assert exec.close() is False
 
 
-def test_validate_executable_path_does_not_eexist() -> None:
+def test_validate_executable_path_does_not_exist() -> None:
+    """
+    `validate_executable_path` should raise a ValueError when the provided executable does not
+    exist.
+    """
     with pytest.raises(ValueError, match="Executable does not exist"):
         ExecutableRunner.validate_executable_path(executable="/path/to/nowhere")
 
 
 def test_validate_executable_path_not_executable() -> None:
+    """
+    `validate_executable_path` should raise a ValueError when the provided executable does not have
+    execute permissions.
+    """
     with NamedTemporaryFile(suffix=".exe", mode="w", delete=True) as tmpfile:
         with pytest.raises(ValueError, match="is not executable"):
             ExecutableRunner.validate_executable_path(executable=tmpfile.name)
@@ -38,9 +46,9 @@ def test_validate_executable_path_returns_existing_paths(executable: str | Path)
     """
     expected_path: Path = Path("/usr/bin/yes")
 
-    with mock.patch.dict(os.environ):
-        # Clear the PATH, in case the user has a local version of `yes` elsewhere on their PATH
-        os.environ.pop("PATH")
+    # Clear the PATH, in case the user has a local version of `yes` elsewhere on their PATH
+    with mock.patch.dict(os.environ, clear=True):
+        os.environ["PATH"] = "/usr/bin"
 
         validated_path: Path = ExecutableRunner.validate_executable_path(executable=executable)
         assert validated_path == expected_path
@@ -62,8 +70,8 @@ def test_validate_executable_path_rejects_paths() -> None:
     """
     `validate_executable_path` should not treat non-existent Path objects as valid executables.
 
-    If the user passes the name of an executable on the PATH as a `Path` instead of a string`, it
-    should be treated as a non-existent Path and a `ValueError` should be raised.
+    Specifically, if the user passes the name of an executable on the PATH as a `Path` instead of a
+    string, it should be treated as a non-existent Path and a `ValueError` should be raised.
     """
     with pytest.raises(ValueError, match="Executable does not exist"):
         ExecutableRunner.validate_executable_path(executable=Path("yes"))

--- a/tests/util/test_executable_runner.py
+++ b/tests/util/test_executable_runner.py
@@ -37,13 +37,13 @@ def test_validate_executable_path(executable: str | Path) -> None:
     1. when the string "yes" is passed
     2. when the absolute path to the `yes` executable is passed, either as a string or a Path
     """
-    expected_path = Path("/usr/bin/yes")
+    expected_path: Path = Path("/usr/bin/yes")
 
     with mock.patch.dict(os.environ):
         # Clear the PATH, in case the user has a local version of `yes` elsewhere on their PATH
         os.environ.pop("PATH")
 
-        validated_path = ExecutableRunner.validate_executable_path(executable=executable)
+        validated_path: Path = ExecutableRunner.validate_executable_path(executable=executable)
         assert validated_path == expected_path
 
 

--- a/tests/util/test_executable_runner.py
+++ b/tests/util/test_executable_runner.py
@@ -38,11 +38,12 @@ def test_validate_executable_path_not_executable() -> None:
             ExecutableRunner.validate_executable_path(executable=tmpfile.name)
 
 
-@pytest.mark.parametrize("executable", ["/usr/bin/yes", Path("/usr/bin/yes")])
-def test_validate_executable_path_returns_existing_paths(executable: str | Path) -> None:
+@pytest.mark.parametrize("executable", ["yes", "/usr/bin/yes", Path("/usr/bin/yes")])
+def test_validate_executable_path(executable: str | Path) -> None:
     """
-    `validate_executable_path` should return the `yes` executable when the absolute path to the
-    executable is passed, either as a string or a Path.
+    `validate_executable_path` should return the `yes` executable in the following scenarios:
+    1. When the name of the executable is passed as a string.
+    2. When the absolute path to the executable is passed, either as a string or a Path.
     """
     expected_path: Path = Path("/usr/bin/yes")
 
@@ -51,18 +52,6 @@ def test_validate_executable_path_returns_existing_paths(executable: str | Path)
         os.environ["PATH"] = "/usr/bin"
 
         validated_path: Path = ExecutableRunner.validate_executable_path(executable=executable)
-        assert validated_path == expected_path
-
-
-def test_validate_executable_finds_on_path() -> None:
-    """
-    `validate_executable_path` should find executables on the PATH when the name of the executable
-    is passed as a string.
-    """
-    expected_path: Path = Path("/usr/bin/yes")
-
-    with mock.patch("shutil.which", return_value=expected_path.as_posix()):
-        validated_path: Path = ExecutableRunner.validate_executable_path(executable="yes")
         assert validated_path == expected_path
 
 

--- a/tests/util/test_executable_runner.py
+++ b/tests/util/test_executable_runner.py
@@ -30,22 +30,21 @@ def test_validate_executable_path_not_executable() -> None:
             ExecutableRunner.validate_executable_path(executable=tmpfile.name)
 
 
-def test_validate_executable_path() -> None:
+@pytest.mark.parametrize("executable", ["yes", "/usr/bin/yes", Path("/usr/bin/yes")])
+def test_validate_executable_path(executable: str | Path) -> None:
     """
     `validate_executable_path` should find the `yes` executable in the following scenarios:
     1. when the string "yes" is passed
     2. when the absolute path to the `yes` executable is passed, either as a string or a Path
     """
-    executables: list[Path | str] = ["yes", "/usr/bin/yes", Path("/usr/bin/yes")]
     expected_path = Path("/usr/bin/yes")
 
     with mock.patch.dict(os.environ):
         # Clear the PATH, in case the user has a local version of `yes` elsewhere on their PATH
         os.environ.pop("PATH")
 
-        for executable in executables:
-            validated_path = ExecutableRunner.validate_executable_path(executable=executable)
-            assert validated_path == expected_path
+        validated_path = ExecutableRunner.validate_executable_path(executable=executable)
+        assert validated_path == expected_path
 
 
 def test_validate_executable_path_rejects_paths() -> None:


### PR DESCRIPTION
Closes #20 

Homebrew installation of the GNU coreutils caused a conflict with expectation in the `ExecutableRunner` validation tests.

Tests were updated to clear the `PATH` before executing.