### PR TITLE
chore: fix PyPi trusted publishing in GitHub Actions

### DIFF
--- a/.github/workflows/publish_prymer.yml
+++ b/.github/workflows/publish_prymer.yml
@@ -1,4 +1,4 @@
-name: publish
+name: publish prymer
 
 on:
   push:
@@ -124,7 +124,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ github.ref_name }}
-          body: |
-            ${{ needs.draft-changelog.outputs.release_body }}
+          body: ${{ needs.make-changelog.outputs.release_body }}
           draft: false
           prerelease: false

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@
 [pypi-link]:            https://pypi.python.org/pypi/prymer
 [pypi-downloads-badge]: https://img.shields.io/pypi/dm/prymer
 [pypi-downloads-link]:  https://pypi.python.org/pypi/prymer
-[python-package-badge]: https://github.com/fulcrumgenomics/prymer/workflows/publish/badge.svg
-[python-package-link]:  https://github.com/fulcrumgenomics/prymer/actions?query=workflow%3A%22Python+package%22
+[python-package-badge]: https://github.com/fulcrumgenomics/prymer/workflows/publish_prymer/badge.svg
+[python-package-link]:  https://github.com/fulcrumgenomics/prymer/actions/workflows/publish_prymer.yml
 
 ## Quick setup
 


### PR DESCRIPTION
Closes: https://github.com/fulcrumgenomics/prymer/issues/3
Closes: https://github.com/fulcrumgenomics/prymer/issues/24

And the updated PyPi trusted publisher config:

<img width="671" alt="Screenshot 2024-09-18 at 11 25 30 AM" src="https://github.com/user-attachments/assets/7a4c3616-3dde-44bb-92a7-91a319440413">
