### PR TITLE
refactor: export Primer3Parameters and Primer3Weights

### DIFF
--- a/prymer/primer3/__init__.py
+++ b/prymer/primer3/__init__.py
@@ -4,9 +4,11 @@ from prymer.primer3.primer3 import Primer3Result
 from prymer.primer3.primer3_failure_reason import Primer3FailureReason
 from prymer.primer3.primer3_input import Primer3Input
 from prymer.primer3.primer3_input_tag import Primer3InputTag
+from prymer.primer3.primer3_parameters import Primer3Parameters
 from prymer.primer3.primer3_task import DesignLeftPrimersTask
 from prymer.primer3.primer3_task import DesignPrimerPairsTask
 from prymer.primer3.primer3_task import DesignRightPrimersTask
+from prymer.primer3.primer3_weights import Primer3Weights
 
 __all__ = [
     "Primer3",
@@ -18,4 +20,6 @@ __all__ = [
     "DesignLeftPrimersTask",
     "DesignPrimerPairsTask",
     "DesignRightPrimersTask",
+    "Primer3Parameters",
+    "Primer3Weights",
 ]


### PR DESCRIPTION
I think these should both be in the `primer3` namespace 