### PR TITLE
doc: Expand the documentation for `OffTargetDetector`

### DIFF
--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -358,10 +358,27 @@ class OffTargetDetector:
         return result
 
     def mappings_of(self, primers: list[PrimerType]) -> dict[str, BwaResult]:
-        """Function to take a set of primers and map any that are not cached, and return mappings
-        for all of them.  Note: the genomics sequence of the returned mappings are on the opposite
-        strand of that of the strand of the primer.  I.e. we map the complementary bases (reversed)
-        to that of the primer."""
+        """
+        Map primers to the reference genome using `bwa aln`.
+
+        Alignment results may be optionally cached for efficiency. Set `cache_results` to `True`
+        when instantiating the [[OffTargetDetector]] to enable caching.
+
+        Any primers without cached results, or all primers when `cache_results` is `False`, will be
+        mapped to the reference genome using `bwa aln` and the specified alignment parameters.
+
+        **Note**: The reverse complement of each primer sequence is used for mapping. The `query`
+        sequence in each `BwaResult` will match the input primer sequence, as will the sequences
+        used as keys in the output dictionary. However, the coordinates reported in each `BwaHit`
+        associated with a result will correspond to complementary sequence.
+
+        Args:
+            primers: A list of primers to map.
+
+        Returns:
+            A dictionary mapping each primer's sequence to its alignment results.
+            See `BwaResult` for details regarding the attributes included in each result.
+        """
 
         primers_to_map: list[PrimerType]
         if not self._cache_results:

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -107,8 +107,9 @@ class OffTargetResult:
             pair would generate an acceptable number of amplicons in the reference genome (i.e.
             `min_primer_pair_hits <= num_amplicons <= max_primer_pair_hits`). False otherwise.
         cached: True if this result is part of a cache, False otherwise.  This is useful for testing
-        spans: the set of mappings of the primer pair to the genome or an empty list if mappings
-            were not retained
+        spans: The set of mappings of the primer pair to the genome (i.e., the region spanned by the
+            inferred amplicon). This list will be empty if the generating [[OffTargetDetector]] was
+            constructed with `keep_spans=False`.
         left_primer_spans: the list of mappings for the left primer, independent of the pair
             mappings, or an empty list
         right_primer_spans: the list of mappings for the right primer, independent of the pair

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -165,6 +165,19 @@ class OffTargetDetector:
         executable: str | Path = "bwa",
     ) -> None:
         """
+        Initialize an [[OffTargetDetector]].
+
+        This class accepts a large number of parameters to control the behavior of the off-target
+        detection. The parameters are used in the various aspects of off-target detection as
+        follows:
+
+        1. Alignment (off-target hit detection): `ref`, `executable`, `threads`,
+           `three_prime_region_length`, `max_mismatches_in_three_prime_region`, `max_mismatches`,
+           and `max_primer_hits`.
+        2. Filtering of individual primers: `max_primer_hits`.
+        3. Checking of primer pairs: `max_primer_hits`, `min_primer_pair_hits`,
+           `max_primer_pair_hits`, and `max_amplicon_size`.
+
         Args:
             ref: the reference genome fasta file (must be indexed with BWA)
             max_primer_hits: the maximum number of hits an individual primer can have in the genome
@@ -188,10 +201,10 @@ class OffTargetDetector:
             max_amplicon_size: the maximum amplicon size to consider amplifiable
             cache_results: if True, cache results for faster re-querying
             threads: the number of threads to use when invoking bwa
-            keep_spans: if True, [[OffTargetResult]] objects will have amplicon spans
+            keep_spans: if True, [[OffTargetResult]] objects will be reported with amplicon spans
                 populated, otherwise not
-            keep_primer_spans: if True, [[OffTargetResult]] objects will have left and right
-                primer spans
+            keep_primer_spans: if True, [[OffTargetResult]] objects will be reported with left and
+                right primer spans
             executable: string or Path representation of the `bwa` executable path
         """
         self._primer_cache: dict[str, BwaResult] = {}

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -233,7 +233,7 @@ class OffTargetDetector:
 
         This method maps each primer to the specified reference with `bwa aln` to search for
         off-target hits. Note that when the reference includes the sequence from which the primers
-        were design, the on-target hit will be included in the hit count. `max_primer_hits` should
+        were designed, the on-target hit will be included in the hit count. `max_primer_hits` should
         be set to at least 1 in this case.
 
         Args:

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -136,7 +136,7 @@ class OffTargetDetector:
     Note that while this class invokes BWA with multiple threads, it is not itself thread-safe.
     Only one thread at a time should invoke methods on this class without external synchronization.
 
-    Off-target detection may be performed for individual primers or primer pairs.
+    Off-target detection may be performed for individual primers and/or primer pairs.
 
     To detect off-target hits for individual primers, use the `OffTargetDetector.filters()` method,
     which will remove any primers that have more than the specified number of maximum hits against


### PR DESCRIPTION
I added documentation to explain how the class can be used to filter primers vs primer pairs, and the behavior of each filtering method. 

I also added `Args` and `Return` blocks to the public methods.