### PR TITLE
feat: add `Probe` object to wrap probe design results from Primer3

### DIFF
--- a/prymer/api/probe.py
+++ b/prymer/api/probe.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+from fgpyo.util.metric import Metric
+
+from prymer.api.primer import Primer
+
+
+@dataclass(frozen=True, init=True, kw_only=True, slots=True)
+class Probe(Primer, Metric["Probe"]):
+    """Stores the properties of the designed Probe. Inherits `tm`, `penalty`,
+    `span`, `bases`, and `tail` from `Primer`.
+
+    Attributes:
+        self_any_th: self-complementarity throughout the probe as calculated by Primer3
+        self_end_th: 3' end complementarity of the probe as calculated by Primer3
+        hairpin_th: hairpin formation thermodynamics of the probe as calculated by Primer3
+
+    """
+
+    self_any_th: float
+    self_end_th: float
+    hairpin_th: float


### PR DESCRIPTION
Originally we wanted to add a `Probe` object that inherits from `Primer` and added additional attributes of a probe. We have decided to change course to refactor `Primer` and `Probe` into the same dataclass, `Oligo`. Standby for refactor.