### PR TITLE
feat: Primer3 takes a list of VCFs instead of a VariantLookup object

### DIFF
--- a/prymer/api/__init__.py
+++ b/prymer/api/__init__.py
@@ -8,13 +8,13 @@ from prymer.api.primer_pair import PrimerPair
 from prymer.api.span import BedLikeCoords
 from prymer.api.span import Span
 from prymer.api.span import Strand
-from prymer.api.variant_lookup import FileBasedVariantLookup
 from prymer.api.variant_lookup import SimpleVariant
+
+# from prymer.api.variant_lookup import _DiskBasedLookup
+# from prymer.api.variant_lookup import _InMemoryLookup
+# from prymer.api.variant_lookup import _VariantLookup
 from prymer.api.variant_lookup import VariantLookup
-from prymer.api.variant_lookup import VariantOverlapDetector
 from prymer.api.variant_lookup import VariantType
-from prymer.api.variant_lookup import cached
-from prymer.api.variant_lookup import disk_based
 
 __all__ = [
     "ClusteredIntervals",
@@ -30,8 +30,4 @@ __all__ = [
     "VariantType",
     "SimpleVariant",
     "VariantLookup",
-    "FileBasedVariantLookup",
-    "VariantOverlapDetector",
-    "cached",
-    "disk_based",
 ]

--- a/prymer/api/variant_lookup.py
+++ b/prymer/api/variant_lookup.py
@@ -1,10 +1,9 @@
 """
 # Variant Lookup Class and Methods
 
-This module contains the abstract class
-[`VariantLookup`][prymer.api.variant_lookup.VariantLookup] to facilitate retrieval of
-variants that overlap a given genomic coordinate range.  Concrete implementations must implement the
-[`query()`][prymer.api.variant_lookup.VariantLookup.query] method for retrieving variants
+This module contains the class [`VariantLookup`][prymer.api.variant_lookup.VariantLookup] to
+facilitate retrieval of variants that overlap a given genomic coordinate range.
+The [`query()`][`prymer.api.variant_lookup.VariantLookup.query`] method is used to retrieve variants
 that overlap the given range.
 
 [`VariantLookup`][prymer.api.variant_lookup.VariantLookup] needs a list of VCF files to be queried,
@@ -345,7 +344,6 @@ class VariantLookup(ContextManager):
         maf: Optional[float] = None,
         include_missing_mafs: bool = None,
     ) -> list[SimpleVariant]:
-
         maf = maf if maf is not None else self.min_maf
         include_missing_mafs = (
             include_missing_mafs if include_missing_mafs is not None else self.include_missing_mafs

--- a/tests/api/test_variant_lookup.py
+++ b/tests/api/test_variant_lookup.py
@@ -19,7 +19,6 @@ from prymer.api.variant_lookup import VariantLookup
 from prymer.api.variant_lookup import VariantType
 from prymer.api.variant_lookup import _DiskBasedLookup
 from prymer.api.variant_lookup import _InMemoryLookup
-from prymer.api.variant_lookup import _VariantLookup
 from prymer.api.variant_lookup import calc_maf_from_filter
 
 
@@ -380,7 +379,7 @@ def get_simple_variant_approx_by_id(*variant_id: str) -> list[SimpleVariant]:
 
 
 def variant_overlap_detector_query(
-    detector: VariantLookup | _VariantLookup,
+    detector: VariantLookup,
     refname: str,
     start: int,
     end: int,
@@ -537,8 +536,8 @@ def test_calc_maf_from_gt_only() -> None:
 
 def test_variant_overlap_detector_query(vcf_path: Path) -> None:
     """Test `VariantOverlapDetector.query()` positional filtering."""
-    variant_overlap_detector = _InMemoryLookup(
-        vcf_paths=[vcf_path], min_maf=0.0, include_missing_mafs=True
+    variant_overlap_detector = VariantLookup(
+        vcf_paths=[vcf_path], min_maf=0.0, include_missing_mafs=True, cached=True
     )
 
     # query for all variants


### PR DESCRIPTION
Closes #53.

Summary:
* We want users to be able to provide `Primer3` with either a list of VCF paths OR a pre-constructed `VariantLookup` object if they would like to cutomize the settings (e.g., MAF filtering). 
* The choice of `VariantLookup` does not need to be exposed to users -- so this PR changes the `VariantLookup` API to such that, under the hood, the correct `VariantLookup` object is created. Depending on the value of the boolean flag `cached`, either a `_InMemoryLookup` or `_DiskBasedLookup` object is constructed. 
* The `Primer3` invocation is changed to optionally accept a list of VCF `Path`s or `VariantLookup` object (with default `cached=True`).


Tests are updated accordingly. Both the public and private objects are tested directly (so I intentionally did not address some of the comments made by coderabbit).