### PR TITLE
feat: remove pysam and bwa warmup hack

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,11 @@ jobs:
         PYTHON_VERSION: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout fulcrumgenomics/bwa
+      - name: Checkout fulcrumgenomics/bwa-aln-interactive
         uses: actions/checkout@v4
         with:
-          repository: fulcrumgenomics/bwa
-          ref: interactive_aln
+          repository: fulcrumgenomics/bwa-aln-interactive
+          ref: main
           path: bwa
           fetch-depth: 0
 

--- a/prymer/offtarget/bwa.py
+++ b/prymer/offtarget/bwa.py
@@ -339,6 +339,7 @@ class BwaAlnInteractive(ExecutableRunner):
         for query in queries:
             # get the next alignment and convert to a result
             line: str = next(self._subprocess.stdout).strip()
+            assert not line.startswith("@"), f"SAM record must not start with '@'! {line}"
             alignment = AlignedSegment.fromstring(line, self.header)
             results.append(self._to_result(query=query, rec=alignment))
 

--- a/prymer/offtarget/bwa.py
+++ b/prymer/offtarget/bwa.py
@@ -33,6 +33,7 @@ BwaHit(refname='chr1', start=61, negative=False, cigar=Cigar(elements=(CigarElem
 >>> bwa.map_all(queries=[query])
 [BwaResult(query=Query(id='NA', bases='AAAAAA'), hit_count=3968, hits=[])]
 >>> bwa.close()
+True
 
 ```
 """  # noqa: E501

--- a/tests/offtarget/test_bwa.py
+++ b/tests/offtarget/test_bwa.py
@@ -2,6 +2,8 @@ import shutil
 from dataclasses import replace
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from typing import TypeAlias
+from typing import cast
 
 import pytest
 from fgpyo.sam import Cigar
@@ -11,6 +13,9 @@ from prymer.offtarget.bwa import BWA_AUX_EXTENSIONS
 from prymer.offtarget.bwa import BwaAlnInteractive
 from prymer.offtarget.bwa import BwaHit
 from prymer.offtarget.bwa import Query
+
+SamHeaderType: TypeAlias = dict[str, dict[str, str] | list[dict[str, str]]]
+"""A type alias for a SAM sequence header dictionary."""
 
 
 @pytest.mark.parametrize("bases", [None, ""])
@@ -66,6 +71,19 @@ def test_hit_build_rc() -> None:
     # things that change
     assert hit_f.negative != hit_r.negative
     assert hit_r.negative is True
+
+
+def test_header_is_properly_constructed(ref_fasta: Path) -> None:
+    """Tests that bwa will return a properly constructed header."""
+    with BwaAlnInteractive(ref=ref_fasta, max_hits=1) as bwa:
+        header: SamHeaderType = bwa.header.to_dict()
+        assert set(header.keys()) == {"HD", "SQ", "PG"}
+        assert header["HD"] == {"GO": "query", "SO": "unsorted", "VN": "1.5"}
+        assert header["SQ"] == [{"LN": 10001, "SN": "chr1"}]
+        assert len(header["PG"]) == 1
+        program_group: dict[str, str] = cast(list[dict[str, str]], header["PG"])[0]
+        program_group["ID"] = "bwa"
+        program_group["PN"] = "bwa"
 
 
 def test_map_one_uniquely_mapped(ref_fasta: Path) -> None:

--- a/tests/offtarget/test_bwa.py
+++ b/tests/offtarget/test_bwa.py
@@ -82,8 +82,8 @@ def test_header_is_properly_constructed(ref_fasta: Path) -> None:
         assert header["SQ"] == [{"LN": 10001, "SN": "chr1"}]
         assert len(header["PG"]) == 1
         program_group: dict[str, str] = cast(list[dict[str, str]], header["PG"])[0]
-        program_group["ID"] = "bwa"
-        program_group["PN"] = "bwa"
+        assert program_group["ID"] == "bwa"
+        assert program_group["PN"] == "bwa"
 
 
 def test_map_one_uniquely_mapped(ref_fasta: Path) -> None:


### PR DESCRIPTION
It is mentioned `pysam.AlignmentFile` internally buffers stdin so a hack was devised to "warm it up".

However, `fgpyo.sam.reader` and `pysam.AlignmentFile` are actually not needed and only provide code indirection since we can build the SAM header and all subsequent records using the [`from_text()`](https://pysam.readthedocs.io/en/latest/api.html#pysam.AlignmentHeader.from_text)/[`fromstring()`](https://pysam.readthedocs.io/en/latest/api.html#pysam.AlignedSegment.fromstring) methods of each.