### PR TITLE
fix: Check against `HN` tag instead of `is_unmapped` property

### DIFF
--- a/prymer/offtarget/bwa.py
+++ b/prymer/offtarget/bwa.py
@@ -374,7 +374,14 @@ class BwaAlnInteractive(ExecutableRunner):
             )
 
         num_hits: int = int(rec.get_tag("HN")) if rec.has_tag("HN") else 0
-        hits: list[BwaHit] = self.to_hits(rec=rec) if 0 < num_hits <= self.max_hits else []
+        hits: list[BwaHit] = self.to_hits(rec=rec) if 0 < num_hits < self.max_hits else []
+
+        # `to_hits()` removes artifactual hits which span the boundary between concatenated
+        # reference sequences. If we are reporting a list of hits, the number of hits should match
+        # the size of this list. Otherwise, we either have zero hits, or more than the maximum
+        # number of hits. In both of the latter cases, we have to rely on the count reported in the
+        # `HN` tag.
+        num_hits = len(hits) if hits else num_hits
 
         return BwaResult(query=query, hit_count=num_hits, hits=hits)
 

--- a/prymer/offtarget/bwa.py
+++ b/prymer/offtarget/bwa.py
@@ -374,14 +374,17 @@ class BwaAlnInteractive(ExecutableRunner):
             )
 
         num_hits: int = int(rec.get_tag("HN")) if rec.has_tag("HN") else 0
-        hits: list[BwaHit] = self.to_hits(rec=rec) if 0 < num_hits < self.max_hits else []
-
         # `to_hits()` removes artifactual hits which span the boundary between concatenated
         # reference sequences. If we are reporting a list of hits, the number of hits should match
         # the size of this list. Otherwise, we either have zero hits, or more than the maximum
         # number of hits. In both of the latter cases, we have to rely on the count reported in the
         # `HN` tag.
-        num_hits = len(hits) if hits else num_hits
+        hits: list[BwaHit]
+        if 0 < num_hits < self.max_hits:
+            hits = self.to_hits(rec=rec)
+            num_hits = len(hits)
+        else:
+            hits = []
 
         return BwaResult(query=query, hit_count=num_hits, hits=hits)
 

--- a/prymer/offtarget/bwa.py
+++ b/prymer/offtarget/bwa.py
@@ -421,4 +421,9 @@ class BwaAlnInteractive(ExecutableRunner):
         if not self.include_alt_hits:
             hits = [hit for hit in hits if not hit.refname.endswith("_alt")]
 
+        # Remove hits that extend beyond the end of a contig - these are artifacts of `bwa aln`'s
+        # alignment process, which concatenates all reference sequences and reports hits which span
+        # across contigs.
+        hits = [hit for hit in hits if hit.end <= self.header.get_reference_length(hit.refname)]
+
         return hits

--- a/prymer/offtarget/bwa.py
+++ b/prymer/offtarget/bwa.py
@@ -434,6 +434,9 @@ class BwaAlnInteractive(ExecutableRunner):
         # Remove hits that extend beyond the end of a contig - these are artifacts of `bwa aln`'s
         # alignment process, which concatenates all reference sequences and reports hits which span
         # across contigs.
-        hits = [hit for hit in hits if hit.end <= self.header.get_reference_length(hit.refname)]
+        # NB: the type ignore is necessary because pysam's type hint for `get_reference_length` is
+        # incorrect.
+        # https://github.com/pysam-developers/pysam/pull/1313
+        hits = [hit for hit in hits if hit.end <= self.header.get_reference_length(hit.refname)]  # type: ignore[arg-type]  # noqa: E501
 
         return hits

--- a/prymer/offtarget/bwa.py
+++ b/prymer/offtarget/bwa.py
@@ -167,7 +167,7 @@ class BwaHit:
 class BwaResult:
     """
     Represents zero or more hits or alignments found by BWA for the given query.
-    
+
     The number of hits found may be more than the number of hits listed in the `hits` attribute.
 
     Attributes:
@@ -380,7 +380,7 @@ class BwaAlnInteractive(ExecutableRunner):
         # number of hits. In both of the latter cases, we have to rely on the count reported in the
         # `HN` tag.
         hits: list[BwaHit]
-        if 0 < num_hits < self.max_hits:
+        if 0 < num_hits <= self.max_hits:
             hits = self.to_hits(rec=rec)
             num_hits = len(hits)
         else:


### PR DESCRIPTION
Closes #68 

`bwa aln` produces inconsistent behavior when recording the mapped status of multiply mapping reads. In most cases, such reads are flagged as mapped with a mapq of 0. However, we have discovered some cases where these reads are flagged as unmapped. 

`prymer` currently relies on the unmapped flag to identify reads with a hit count of zero. This has been yielding errors when attempting to parse reads in the latter category. This information can instead be obtained directly from the `HN` tag.

---

NB: Thanks to detective work by @tfenne 

> This happens because internally bwa concatenates all the sequences in the FASTA file, so it can discover hits that extend across contig boundaries.  Unfortunately when it discovers it’s done this on the mapping selected as the primary mapping, it just marks it as unmapped instead of removing the mapping entirely (and selecting a different primary mapping if there are secondary hits).

This PR additionally discards any hits that extend beyond the end of the contig to which they are mapped.
