### PR TITLE
fix: ensure ExecutableRunner stderr goes somewhere by default

### DIFF
--- a/prymer/util/executable_runner.py
+++ b/prymer/util/executable_runner.py
@@ -42,7 +42,7 @@ class ExecutableRunner(AbstractContextManager):
         command: list[str],
         stdin: int = subprocess.PIPE,
         stdout: int = subprocess.PIPE,
-        stderr: int = subprocess.PIPE,
+        stderr: int = subprocess.DEVNULL,
     ) -> None:
         if len(command) == 0:
             raise ValueError(f"Invocation must not be empty, received {command}")


### PR DESCRIPTION
This doesn't fully solve:

- https://github.com/fulcrumgenomics/prymer/issues/41

But it should solve the issue where the stderr PIPE's buffer may become full and deadlock the process.