### PR TITLE
feat: redirect BwaAlnInteractive stderr to debug logging

### DIFF
--- a/prymer/offtarget/bwa.py
+++ b/prymer/offtarget/bwa.py
@@ -321,7 +321,7 @@ class BwaAlnInteractive(ExecutableRunner):
         self._stderr_thread = Thread(
             daemon=True,
             target=self._stream_to_sink,
-            args=(self._subprocess.stderr, lambda line: self._logger.debug(line)),
+            args=(self._subprocess.stderr, self._logger.debug),
         )
         self._stderr_thread.start()
 

--- a/prymer/util/executable_runner.py
+++ b/prymer/util/executable_runner.py
@@ -84,11 +84,11 @@ class ExecutableRunner(AbstractContextManager):
         self.close()
 
     @staticmethod
-    def _stream_to_sink(stream: TextIO, sync: Callable[[str], None]) -> None:
+    def _stream_to_sink(stream: TextIO, sink: Callable[[str], None]) -> None:
         """Redirect a text IO stream to a text sink."""
         while True:
             if line := stream.readline():
-                sync(line.rstrip())
+                sink(line.rstrip())
             else:
                 break
 

--- a/prymer/util/executable_runner.py
+++ b/prymer/util/executable_runner.py
@@ -14,8 +14,10 @@ import subprocess
 from contextlib import AbstractContextManager
 from pathlib import Path
 from types import TracebackType
+from typing import Callable
 from typing import Optional
 from typing import Self
+from typing import TextIO
 
 
 class ExecutableRunner(AbstractContextManager):
@@ -30,6 +32,12 @@ class ExecutableRunner(AbstractContextManager):
     Subclasses of [`ExecutableRunner`][prymer.util.executable_runner.ExecutableRunner]
     provide additional type checking of inputs and orchestrate parsing output data from specific
     command-line tools.
+
+    Warning:
+        Users of this class must be acutely aware of deadlocks that can exist when manually
+        writing and reading to subprocess pipes. The Python documentation for subprocess and PIPE
+        has warnings to this effect as well as recommended workarounds and alternatives.
+        https://docs.python.org/3/library/subprocess.html
     """
 
     __slots__ = ("_command", "_subprocess", "_name")
@@ -40,9 +48,13 @@ class ExecutableRunner(AbstractContextManager):
     def __init__(
         self,
         command: list[str],
+        # NB: users of this class must be acutely aware of deadlocks that can exist when manually
+        # writing and reading to subprocess pipes. The Python documentation for subprocess and PIPE
+        # has warnings to this effect as well as recommended workarounds and alternatives.
+        # https://docs.python.org/3/library/subprocess.html
         stdin: int = subprocess.PIPE,
         stdout: int = subprocess.PIPE,
-        stderr: int = subprocess.PIPE,
+        stderr: int = subprocess.DEVNULL,
     ) -> None:
         if len(command) == 0:
             raise ValueError(f"Invocation must not be empty, received {command}")
@@ -70,6 +82,15 @@ class ExecutableRunner(AbstractContextManager):
         """Gracefully terminates any running subprocesses."""
         super().__exit__(exc_type, exc_value, traceback)
         self.close()
+
+    @staticmethod
+    def _stream_to_sink(stream: TextIO, sync: Callable[[str], None]) -> None:
+        """Redirect a text IO stream to a text sink."""
+        while True:
+            if line := stream.readline():
+                sync(line.rstrip())
+            else:
+                break
 
     @classmethod
     def validate_executable_path(cls, executable: str | Path) -> Path:
@@ -115,8 +136,7 @@ class ExecutableRunner(AbstractContextManager):
 
     def close(self) -> bool:
         """
-        Gracefully terminates the underlying subprocess if it is still
-        running.
+        Gracefully terminates the underlying subprocess if it is still running.
 
         Returns:
             True: if the subprocess was terminated successfully


### PR DESCRIPTION
This doesn't fully close:

- https://github.com/fulcrumgenomics/prymer/issues/41

But it does redirect the stderr stream to a debug logger.

Users of this library can override the logging level of all loggers/handles to be able to view these log messages if they choose, but a convenient way to change the logging levels within prymer does not yet exist and could be implemented in a future PR.