### PR TITLE
Emit primer pairs in penalty order.

### DIFF
--- a/prymer/api/picking.py
+++ b/prymer/api/picking.py
@@ -121,7 +121,8 @@ def build_primer_pairs(  # noqa: C901
         fasta_path: the path to the FASTA file from which the amplicon sequence will be retrieved.
 
     Returns:
-        an iterator over all the valid primer pairs, sorted by primer pair penalty
+        An iterator over all the valid primer pairs, sorted by primer pair penalty. 
+        Primer pairs with smaller penalties are returned first.
     """
     # Short circuit if we have no left primers or no right primers
     if not any(left_primers) or not any(right_primers):

--- a/prymer/api/picking.py
+++ b/prymer/api/picking.py
@@ -121,7 +121,7 @@ def build_primer_pairs(  # noqa: C901
         fasta_path: the path to the FASTA file from which the amplicon sequence will be retrieved.
 
     Returns:
-        an iterator over all the valid primer pairs, unsorted
+        an iterator over all the valid primer pairs, sorted by primer pair penalty
     """
     # Short circuit if we have no left primers or no right primers
     if not any(left_primers) or not any(right_primers):

--- a/prymer/api/picking.py
+++ b/prymer/api/picking.py
@@ -121,7 +121,7 @@ def build_primer_pairs(  # noqa: C901
         fasta_path: the path to the FASTA file from which the amplicon sequence will be retrieved.
 
     Returns:
-        An iterator over all the valid primer pairs, sorted by primer pair penalty. 
+        An iterator over all the valid primer pairs, sorted by primer pair penalty.
         Primer pairs with smaller penalties are returned first.
     """
     # Short circuit if we have no left primers or no right primers

--- a/tests/api/test_picking.py
+++ b/tests/api/test_picking.py
@@ -274,7 +274,7 @@ def test_build_primers_amplicon_size_filtering(
     pairs = list(
         picking.build_primer_pairs(
             left_primers=[p("A" * 20, tm=60, pos=s, pen=1.0) for s in range(1, 151, 10)],
-            right_primers=[p("A" * 20, tm=60, pos=s, pen=1.0) for s in range(151, 301, 10)],
+            right_primers=[p("A" * 20, tm=60, pos=s, pen=1.0) for s in range(101, 301, 10)],
             target=Span("chr1", 150, 160),
             amplicon_sizes=MinOptMax(100, 150, 200),
             amplicon_tms=MinOptMax(0.0, 0.0, 100.0),

--- a/tests/api/test_picking.py
+++ b/tests/api/test_picking.py
@@ -273,8 +273,8 @@ def test_build_primers_amplicon_size_filtering(
 ) -> None:
     pairs = list(
         picking.build_primer_pairs(
-            left_primers=[p("A" * 20, tm=60, pos=s, pen=1.0) for s in range(1, 151, 10)],
-            right_primers=[p("A" * 20, tm=60, pos=s, pen=1.0) for s in range(101, 301, 10)],
+            left_primers=[p("A" * 20, tm=60, pos=s, pen=1.0) for s in range(51, 301, 10)],
+            right_primers=[p("A" * 20, tm=60, pos=s, pen=1.0) for s in range(1, 401, 10)],
             target=Span("chr1", 150, 160),
             amplicon_sizes=MinOptMax(100, 150, 200),
             amplicon_tms=MinOptMax(0.0, 0.0, 100.0),


### PR DESCRIPTION
This PR does two things:

1. Fix a bug where amplicons that were too _small_ were still emitted
2. Ensure that primer pairs are emitted in penalty order

(2) requires materializing a small tuple for all _valid_ pairs, and then sorting by score.  The tuple contains two ints (indices into the primer sequences) and two floats (the penalty and the tm, the last for convenience so we don't have to recompute it).  It the sorts the tuples by penalty, and starts generating PrimerPairs in penalty order.

If you have e.g. 500 left and 500 right primers, this could construct ~250k tuples and calculate 250k Tms, but in reality the number is probably substantially smaller constrained by amplicon sizes.