### PR TITLE
Make sure logger.getLogger() is used instead of logging directly via logging.debug()

### DIFF
--- a/prymer/api/picking.py
+++ b/prymer/api/picking.py
@@ -16,6 +16,7 @@ Contains the following public classes and methods:
     from individual left and primers.
 
 """
+
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Iterator

--- a/prymer/api/variant_lookup.py
+++ b/prymer/api/variant_lookup.py
@@ -80,6 +80,8 @@ from strenum import UppercaseStrEnum
 from prymer.api.span import Span
 from prymer.api.span import Strand
 
+_logger = logging.getLogger(__name__)
+
 
 @unique
 class VariantType(UppercaseStrEnum):
@@ -282,9 +284,7 @@ class VariantLookup(ABC):
 
         variants = self._query(refname=refname, start=start, end=end)
         if len(variants) == 0:
-            logging.getLogger(__name__).debug(
-                f"No variants extracted from region of interest: {refname}:{start}-{end}"
-            )
+            _logger.debug(f"No variants extracted from region of interest: {refname}:{start}-{end}")
         if maf is None or maf <= 0.0:
             return variants
         elif include_missing_mafs:  # return variants with a MAF above threshold or missing
@@ -313,7 +313,7 @@ class VariantLookup(ABC):
             ):  # if passing or empty filters
                 simple_variants = SimpleVariant.build(variant)
                 if any(v.variant_type == VariantType.OTHER for v in simple_variants):
-                    logging.getLogger(__name__).debug(
+                    _logger.debug(
                         f"Input VCF file {source_vcf} may contain complex variants: {variant}"
                     )
                 simple_vars.extend(simple_variants)
@@ -374,9 +374,7 @@ class FileBasedVariantLookup(ContextManager, VariantLookup):
         simple_variants: list[SimpleVariant] = []
         for fh, path in zip(self._readers, self.vcf_paths, strict=True):
             if not fh.header.contigs.get(refname):
-                logging.getLogger(__name__).debug(
-                    f"Header in VCF file {path} does not contain chromosome {refname}."
-                )
+                _logger.debug(f"Header in VCF file {path} does not contain chromosome {refname}.")
                 continue
             #  pysam.fetch is 0-based, half-open
             variants = [variant for variant in fh.fetch(contig=refname, start=start - 1, end=end)]

--- a/prymer/api/variant_lookup.py
+++ b/prymer/api/variant_lookup.py
@@ -282,7 +282,9 @@ class VariantLookup(ABC):
 
         variants = self._query(refname=refname, start=start, end=end)
         if len(variants) == 0:
-            logging.debug(f"No variants extracted from region of interest: {refname}:{start}-{end}")
+            logging.getLogger(__name__).debug(
+                f"No variants extracted from region of interest: {refname}:{start}-{end}"
+            )
         if maf is None or maf <= 0.0:
             return variants
         elif include_missing_mafs:  # return variants with a MAF above threshold or missing
@@ -311,7 +313,7 @@ class VariantLookup(ABC):
             ):  # if passing or empty filters
                 simple_variants = SimpleVariant.build(variant)
                 if any(v.variant_type == VariantType.OTHER for v in simple_variants):
-                    logging.debug(
+                    logging.getLogger(__name__).debug(
                         f"Input VCF file {source_vcf} may contain complex variants: {variant}"
                     )
                 simple_vars.extend(simple_variants)
@@ -372,7 +374,9 @@ class FileBasedVariantLookup(ContextManager, VariantLookup):
         simple_variants: list[SimpleVariant] = []
         for fh, path in zip(self._readers, self.vcf_paths, strict=True):
             if not fh.header.contigs.get(refname):
-                logging.debug(f"Header in VCF file {path} does not contain chromosome {refname}.")
+                logging.getLogger(__name__).debug(
+                    f"Header in VCF file {path} does not contain chromosome {refname}."
+                )
                 continue
             #  pysam.fetch is 0-based, half-open
             variants = [variant for variant in fh.fetch(contig=refname, start=start - 1, end=end)]

--- a/prymer/primer3/primer3.py
+++ b/prymer/primer3/primer3.py
@@ -268,7 +268,7 @@ class Primer3(ExecutableRunner):
         self._fasta.close()
         subprocess_close = super().close()
         if not subprocess_close:
-            logging.debug("Did not successfully close underlying subprocess")
+            logging.getLogger(__name__).debug("Did not successfully close underlying subprocess")
         return subprocess_close
 
     def get_design_sequences(self, region: Span) -> tuple[str, str]:

--- a/prymer/primer3/primer3_failure_reason.py
+++ b/prymer/primer3/primer3_failure_reason.py
@@ -112,7 +112,7 @@ class Primer3FailureReason(StrEnum):
                     continue
                 std_reason = Primer3FailureReason.from_reason(reason)
                 if std_reason is None:
-                    logging.debug(f"Unknown Primer3 failure reason: {reason}")
+                    logging.getLogger(__name__).debug(f"Unknown Primer3 failure reason: {reason}")
                 by_fail_count[std_reason] += count
 
         return by_fail_count

--- a/prymer/util/executable_runner.py
+++ b/prymer/util/executable_runner.py
@@ -70,7 +70,9 @@ class ExecutableRunner(AbstractContextManager):
         )
 
     def __enter__(self) -> Self:
-        logging.debug(f"Initiating {self._name} with the following params: {self._command}")
+        logging.getLogger(__name__).debug(
+            f"Initiating {self._name} with the following params: {self._command}"
+        )
         return self
 
     def __exit__(
@@ -142,15 +144,17 @@ class ExecutableRunner(AbstractContextManager):
             True: if the subprocess was terminated successfully
             False: if the subprocess failed to terminate or was not already running
         """
+        log = logging.getLogger(__name__)
+
         if self.is_alive:
             self._subprocess.terminate()
             self._subprocess.wait(timeout=10)
             if not self.is_alive:
-                logging.debug("Subprocess terminated successfully.")
+                log.debug("Subprocess terminated successfully.")
                 return True
             else:
-                logging.debug("Subprocess failed to terminate.")
+                log.debug("Subprocess failed to terminate.")
                 return False
         else:
-            logging.debug("Subprocess is not running.")
+            log.debug("Subprocess is not running.")
             return False


### PR DESCRIPTION
This small PR ensures that anywhere that `prymer` logs it first gets a logger via `logging.getLogger(__name__)`, rather than just doing `logging.debug(....)`.

The problem with `logging.debug()` (and similar methods directly on the logging module) is that they are side-effecting on the logging configuration.  E.g. here's the `debug()` function in `logging`:

```python
def debug(msg, *args, **kwargs):
    """
    Log a message with severity 'DEBUG' on the root logger. If the logger has
    no handlers, call basicConfig() to add a console handler with a pre-defined
    format.
    """
    if len(root.handlers) == 0:
        basicConfig()
    root.debug(msg, *args, **kwargs)
```

This was causing me issues in a repo that uses `prymer`, where after the first one of these calls, I then received duplicate log messages for every subsequent log in _my_ code.