### PR TITLE
Expose some bwa indel parameters through the off-target checker.

### DIFF
--- a/prymer/offtarget/bwa.py
+++ b/prymer/offtarget/bwa.py
@@ -232,6 +232,7 @@ class BwaAlnInteractive(ExecutableRunner):
         max_mismatches_in_seed: int = 3,
         max_gap_opens: int = 0,
         max_gap_extensions: int = -1,
+        min_indel_to_end_distance: int = 3,
         seed_length: int = 20,
         reverse_complement: bool = False,
         include_alt_hits: bool = False,
@@ -248,6 +249,8 @@ class BwaAlnInteractive(ExecutableRunner):
             max_gap_opens: the maximum number of gap opens allowed in the full query sequence
             max_gap_extensions: the maximum number of gap extensions allowed in the full query
                                 sequence
+            min_indel_to_end_distance: do not place an indel within this many bp of the ends of
+                the query sequence
             seed_length: the length of the seed region
             reverse_complement: reverse complement each query sequence before alignment
             include_alt_hits: if true include hits to references with names ending in _alt,
@@ -288,6 +291,8 @@ class BwaAlnInteractive(ExecutableRunner):
             f"{max_gap_opens}",
             "-e",
             f"{max_gap_extensions}",
+            "-i",
+            f"{min_indel_to_end_distance}",
             "-l",
             f"{seed_length}",
             "-k",

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -159,7 +159,9 @@ class OffTargetDetector(AbstractContextManager):
         three_prime_region_length: int,
         max_mismatches_in_three_prime_region: int,
         max_mismatches: int,
-        max_amplicon_size: int,
+        max_gap_opens: int = 0,
+        max_gap_extends: int = -1,
+        max_amplicon_size: int = 1000,
         min_primer_pair_hits: int = 1,
         cache_results: bool = True,
         threads: Optional[int] = None,
@@ -201,6 +203,12 @@ class OffTargetDetector(AbstractContextManager):
                 three_prime_region_length
             max_mismatches: the maximum number of mismatches allowed in the full length primer
                 (including any in the three prime region)
+            max_gap_opens: the maximum number of gaps (insertions or deletions) allowable in an
+                alignment of a oligo to the reference
+            max_gap_extends: the maximum number of gap extensions allowed; extending a gap
+                beyond a single base costs 1 gap extension.  Can be set to -1 to allow
+                unlimited extensions up to max diffs (aka max mismatches), while disallowing
+                "long gaps".
             max_amplicon_size: the maximum amplicon size to consider amplifiable
             cache_results: if True, cache results for faster re-querying
             threads: the number of threads to use when invoking bwa
@@ -220,6 +228,8 @@ class OffTargetDetector(AbstractContextManager):
             seed_length=three_prime_region_length,
             max_mismatches_in_seed=max_mismatches_in_three_prime_region,
             max_mismatches=max_mismatches,
+            max_gap_opens=max_gap_opens,
+            max_gap_extensions=max_gap_extends,
             max_hits=max_primer_hits,
         )
         self._max_primer_hits = max_primer_hits

--- a/tests/offtarget/test_bwa.py
+++ b/tests/offtarget/test_bwa.py
@@ -222,6 +222,7 @@ def test_map_single_hit(
         max_hits=1,
         max_mismatches=5,
         max_gap_opens=1,
+        min_indel_to_end_distance=5,
         reverse_complement=reverse_complement,
     ) as bwa:
         query = Query(bases=bases, id=f"{hit}")


### PR DESCRIPTION
I did some playing with ntthal, and it appears to that the when calculating Tms of duplexes, an indel closer than 3bp from the end of the primer causes it to see the rest of the primer as non-annealed.  In some cases it can be more (depending on sequence, it may not see the remainder as annealed after an indel 4-5bp in), but it seems consistent that it needs _at least_ 3bp past the indel to anneal bases.  Hence setting `min_indel_to_end_distance: int = 3`.