### PR TITLE
feat: speed improvements for primer pair hit building from single primer hits

### DIFF
--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -470,9 +470,12 @@ class OffTargetDetector(AbstractContextManager):
     def _to_amplicons(
         positive_hits: list[BwaHit], negative_hits: list[BwaHit], max_len: int, strand: Strand
     ) -> list[Span]:
-        """Takes a set of hits for one or more left primers and right primers and constructs
-        amplicon mappings anywhere a left primer hit and a right primer hit align in F/R
-        orientation up to `maxLen` apart on the same reference.  Primers may not overlap.
+        """Takes lists of positive strand hits and negative strand hits and constructs amplicon
+        mappings anywhere a positive strand hit and a negative strand hit occur where the end of
+        the negative strand hit is no more than `max_len` from the start of the positive strand
+        hit.
+
+        Primers may not overlap.
 
         Args:
             positive_hits: List of hits on the positive strand for one of the primers in the pair.

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -373,7 +373,7 @@ class OffTargetDetector(AbstractContextManager):
         # Get the set of reference names with hits
         hits_by_refname: dict[str, PrimerPairBwaHitsBySideAndStrand] = {
             hit.refname: PrimerPairBwaHitsBySideAndStrand()
-            for hit in left_bwa_result.hits + right_bwa_result.hits
+            for hit in itertools.chain(left_bwa_result.hits, right_bwa_result.hits)
         }
 
         # Split the hits for left and right by reference name and strand
@@ -506,7 +506,9 @@ class OffTargetDetector(AbstractContextManager):
         if any(not h.negative for h in negative_hits):
             raise ValueError("Negative hits must be on the negative strand.")
 
-        refnames: set[ReferenceName] = {h.refname for h in positive_hits + negative_hits}
+        refnames: set[ReferenceName] = {
+            h.refname for h in itertools.chain(positive_hits, negative_hits)
+        }
         if len(refnames) > 1:
             raise ValueError("Hits are present on more than one reference.")
 

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -362,6 +362,7 @@ class OffTargetDetector(AbstractContextManager):
             or right_bwa_result.hit_count > self._max_primer_hits
         ):
             result = OffTargetResult(primer_pair=primer_pair, passes=False)
+            return result
 
         # Get the set of reference names with hits
         hits_by_refname: dict[str, PrimerPairBwaHitsBySideAndStrand] = {

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -516,7 +516,7 @@ class OffTargetDetector(AbstractContextManager):
         for positive_hit, negative_hit in itertools.product(positive_hits, negative_hits):
             if (
                 negative_hit.start > positive_hit.end
-                and (negative_hit.end - positive_hit.start + 1) <= max_len
+                and negative_hit.end - positive_hit.start + 1 <= max_len
             ):
                 amplicons.append(
                     Span(

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -362,6 +362,8 @@ class OffTargetDetector(AbstractContextManager):
             or right_bwa_result.hit_count > self._max_primer_hits
         ):
             result = OffTargetResult(primer_pair=primer_pair, passes=False)
+            if self._cache_results:
+                self._primer_pair_cache[primer_pair] = replace(result, cached=True)
             return result
 
         # Get the set of reference names with hits

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -83,6 +83,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Optional
 from typing import Self
+from typing import TypeAlias
 from typing import TypeVar
 
 from ordered_set import OrderedSet
@@ -98,6 +99,9 @@ from prymer.offtarget.bwa import BwaResult
 from prymer.offtarget.bwa import Query
 
 PrimerType = TypeVar("PrimerType", bound=Oligo)
+
+ReferenceName: TypeAlias = str
+"""Alias for a reference sequence name."""
 
 
 @dataclass(init=True, frozen=True)
@@ -502,7 +506,7 @@ class OffTargetDetector(AbstractContextManager):
         if any(not h.negative for h in negative_hits):
             raise ValueError("Negative hits must be on the negative strand.")
 
-        refnames: set[str] = {h.refname for h in positive_hits + negative_hits}
+        refnames: set[ReferenceName] = {h.refname for h in positive_hits + negative_hits}
         if len(refnames) > 1:
             raise ValueError("Hits are present on more than one reference.")
 

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -499,6 +499,11 @@ class OffTargetDetector(AbstractContextManager):
         if len(refnames) > 1:
             raise ValueError(f"Hits are present on more than one reference: {refnames}")
 
+        # Exit early if one of the hit lists is empty - this will save unnecessary sorting of the
+        # other list
+        if len(positive_hits) == 0 or len(negative_hits) == 0:
+            return []
+
         amplicons: list[Span] = []
         for positive_hit, negative_hit in itertools.product(positive_hits, negative_hits):
             if (

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -510,7 +510,7 @@ class OffTargetDetector(AbstractContextManager):
             h.refname for h in itertools.chain(positive_hits, negative_hits)
         }
         if len(refnames) > 1:
-            raise ValueError("Hits are present on more than one reference.")
+            raise ValueError(f"Hits are present on more than one reference: {refnames}")
 
         amplicons: list[Span] = []
         for positive_hit, negative_hit in itertools.product(positive_hits, negative_hits):

--- a/tests/offtarget/test_offtarget.py
+++ b/tests/offtarget/test_offtarget.py
@@ -220,13 +220,13 @@ def test_build_off_target_result(ref_fasta: Path) -> None:
         penalty=0,
     )
 
-    with _build_detector(ref_fasta=ref_fasta) as detector:
+    with _build_detector(
+        ref_fasta=ref_fasta, max_primer_hits=10, max_primer_pair_hits=10
+    ) as detector:
         off_target_result: OffTargetResult = detector._build_off_target_result(
             primer_pair=primer_pair,
             hits_by_primer=hits_by_primer,
         )
-
-    print(off_target_result.spans)
 
     assert off_target_result.spans == [
         Span(refname="chr1", start=100, end=299, strand=Strand.POSITIVE),

--- a/tests/offtarget/test_offtarget.py
+++ b/tests/offtarget/test_offtarget.py
@@ -11,6 +11,7 @@ from prymer.api.span import Strand
 from prymer.offtarget.bwa import BWA_EXECUTABLE_NAME
 from prymer.offtarget.bwa import BwaHit
 from prymer.offtarget.bwa import BwaResult
+from prymer.offtarget.bwa import Query
 from prymer.offtarget.offtarget_detector import OffTargetDetector
 from prymer.offtarget.offtarget_detector import OffTargetResult
 
@@ -171,66 +172,157 @@ def test_mappings_of(ref_fasta: Path, cache_results: bool) -> None:
             assert results_dict[p2.bases].hits[0] == expected_hit2
 
 
+# Test building an OffTargetResult for a primer pair with left/right hits on different references
+# and in different orientations
+def test_build_off_target_result(ref_fasta: Path) -> None:
+    hits_by_primer: dict[str, BwaResult] = {
+        "A" * 100: BwaResult(
+            query=Query(
+                id="left",
+                bases="A" * 100,
+            ),
+            hit_count=3,
+            hits=[
+                BwaHit.build("chr1", 100, False, "100M", 0),
+                BwaHit.build("chr1", 400, True, "100M", 0),
+                BwaHit.build("chr2", 100, False, "100M", 0),
+                BwaHit.build("chr3", 700, True, "100M", 0),
+            ],
+        ),
+        "C" * 100: BwaResult(
+            query=Query(
+                id="right",
+                bases="C" * 100,
+            ),
+            hit_count=2,
+            hits=[
+                BwaHit.build("chr1", 800, False, "100M", 0),
+                BwaHit.build("chr1", 200, True, "100M", 0),
+                BwaHit.build("chr3", 600, False, "100M", 0),
+            ],
+        ),
+    }
+
+    primer_pair = PrimerPair(
+        left_primer=Oligo(
+            tm=50,
+            penalty=0,
+            span=Span(refname="chr10", start=100, end=199, strand=Strand.POSITIVE),
+            bases="A" * 100,
+        ),
+        right_primer=Oligo(
+            tm=50,
+            penalty=0,
+            span=Span(refname="chr10", start=300, end=399, strand=Strand.NEGATIVE),
+            bases="C" * 100,
+        ),
+        amplicon_tm=100,
+        penalty=0,
+    )
+
+    with _build_detector(ref_fasta=ref_fasta) as detector:
+        off_target_result: OffTargetResult = detector._build_off_target_result(
+            primer_pair=primer_pair,
+            hits_by_primer=hits_by_primer,
+        )
+
+    print(off_target_result.spans)
+
+    assert off_target_result.spans == [
+        Span(refname="chr1", start=100, end=299, strand=Strand.POSITIVE),
+        Span(refname="chr3", start=600, end=799, strand=Strand.NEGATIVE),
+    ]
+
+
 # Test that using the cache (or not) does not affect the results
 @pytest.mark.parametrize("cache_results", [True, False])
 @pytest.mark.parametrize(
-    "test_id, left, right, expected",
+    "test_id, positive, negative, strand, expected",
     [
-        (
-            "No mappings - different refnames",
-            BwaHit.build("chr1", 100, False, "100M", 0),
-            BwaHit.build("chr2", 100, True, "100M", 0),
-            [],
-        ),
-        (
-            "No mappings - FF pair",
-            BwaHit.build("chr1", 100, True, "100M", 0),
-            BwaHit.build("chr1", 100, True, "100M", 0),
-            [],
-        ),
-        (
-            "No mappings - RR pair",
-            BwaHit.build("chr1", 100, False, "100M", 0),
-            BwaHit.build("chr1", 100, False, "100M", 0),
-            [],
-        ),
         (
             "No mappings - overlapping primers (1bp overlap)",
             BwaHit.build("chr1", 100, False, "100M", 0),
             BwaHit.build("chr1", 199, True, "100M", 0),
+            Strand.POSITIVE,
             [],
         ),
         (
             "No mappings - amplicon size too big (1bp too big)",
             BwaHit.build("chr1", 100, False, "100M", 0),
             BwaHit.build("chr1", 151, True, "100M", 0),
+            Strand.POSITIVE,
             [],
         ),
         (
             "Mappings - FR pair (R1 F)",
             BwaHit.build("chr1", 100, False, "100M", 0),
             BwaHit.build("chr1", 200, True, "100M", 0),
-            [Span(refname="chr1", start=100, end=299)],
+            Strand.POSITIVE,
+            [Span(refname="chr1", start=100, end=299, strand=Strand.POSITIVE)],
         ),
         (
             "Mappings - FR pair (R1 R)",
-            BwaHit.build("chr1", 200, True, "100M", 0),
             BwaHit.build("chr1", 100, False, "100M", 0),
-            [Span(refname="chr1", start=100, end=299)],
+            BwaHit.build("chr1", 200, True, "100M", 0),
+            Strand.NEGATIVE,
+            [Span(refname="chr1", start=100, end=299, strand=Strand.NEGATIVE)],
         ),
     ],
 )
 def test_to_amplicons(
     ref_fasta: Path,
     test_id: str,
-    left: BwaHit,
-    right: BwaHit,
+    positive: BwaHit,
+    negative: BwaHit,
+    strand: Strand,
     expected: list[Span],
     cache_results: bool,
 ) -> None:
     with _build_detector(ref_fasta=ref_fasta, cache_results=cache_results) as detector:
-        actual = detector._to_amplicons(lefts=[left], rights=[right], max_len=250)
+        actual = detector._to_amplicons(
+            positive_hits=[positive], negative_hits=[negative], max_len=250, strand=strand
+        )
         assert actual == expected, test_id
+
+
+@pytest.mark.parametrize("cache_results", [True, False])
+@pytest.mark.parametrize(
+    "positive, negative, expected_error",
+    [
+        (
+            # No mappings - different refnames
+            BwaHit.build("chr1", 100, False, "100M", 0),
+            BwaHit.build("chr2", 100, True, "100M", 0),
+            "Hits are present on more than one reference",
+        ),
+        (
+            # No mappings - FF pair
+            BwaHit.build("chr1", 100, True, "100M", 0),
+            BwaHit.build("chr1", 100, True, "100M", 0),
+            "Positive hits must be on the positive strand",
+        ),
+        (
+            # No mappings - RR pair
+            BwaHit.build("chr1", 100, False, "100M", 0),
+            BwaHit.build("chr1", 100, False, "100M", 0),
+            "Negative hits must be on the negative strand",
+        ),
+    ],
+)
+def test_to_amplicons_value_error(
+    ref_fasta: Path,
+    positive: BwaHit,
+    negative: BwaHit,
+    expected_error: str,
+    cache_results: bool,
+) -> None:
+    with (
+        _build_detector(ref_fasta=ref_fasta, cache_results=cache_results) as detector,
+        pytest.raises(ValueError, match=expected_error),
+    ):
+        detector._to_amplicons(
+            positive_hits=[positive], negative_hits=[negative], max_len=250, strand=Strand.POSITIVE
+        )
 
 
 def test_generic_filter(ref_fasta: Path) -> None:

--- a/tests/offtarget/test_offtarget.py
+++ b/tests/offtarget/test_offtarget.py
@@ -228,10 +228,10 @@ def test_build_off_target_result(ref_fasta: Path) -> None:
             hits_by_primer=hits_by_primer,
         )
 
-    assert off_target_result.spans == [
+    assert set(off_target_result.spans) == {
         Span(refname="chr1", start=100, end=299, strand=Strand.POSITIVE),
         Span(refname="chr3", start=600, end=799, strand=Strand.NEGATIVE),
-    ]
+    }
 
 
 # Test that using the cache (or not) does not affect the results


### PR DESCRIPTION
Closes #94 

1. `OffTargetDetector._to_amplicons` signature changes from 

```
def _to_amplicons(lefts: list[BwaHit], rights: list[BwaHit], max_len: int) -> list[Span]:
```

to

```
def _to_amplicons(
    positive_hits: list[BwaHit], negative_hits: list[BwaHit], max_len: int, strand: Strand
) -> list[Span]:
```

- Amplicons are built from a list of single primer hits on the positive strand and a list of single primer hits on the negative strand.
- New parameter `strand` is used to set the `strand` attribute on each of the returned `Span`s for the amplicon hits. 
- Validates that all positive hits are on the positive strand and all negative hits are on the negative strand.
- Validates that all hits are on the same reference (e.g. contig/chr).

2. The existing unit test for `OffTargetDetector.to_amplicons` is split into two, one where no error should be raised, and one where a `ValueError` should be raised, with expected error messages.

3. `OffTargetDetector._build_off_target_result` does not change signature.

- exits early setting `pass = False` to the returned `OffTargetResult` if there are too many hits for either the left or the right primer.
- hits are separated by reference (e.g. contig/chr), left/right, and strand (positive/negative) using defaultdict collections
- this enables passing hits that are on the same strand and in the correct relative orientation to each other to `_to_amplicons`, along with a known amplicon strand - positive when the positive hits are from the left primer of a pair and the negative hits are from the right primer, and negative in the inverse.
- the full set of left and right primer hits are still returned if `OffTargetDetector._keep_primer_spans` is `True`.

4. Unit test for `OffTargetDetector._build_off_target_result` is added.
