### PR TITLE
feat: allow for left/right primer hits to overlap when building primer pair hits with `OverlapDetector`

### DIFF
--- a/prymer/api/picking.py
+++ b/prymer/api/picking.py
@@ -165,13 +165,13 @@ def build_primer_pairs(  # noqa: C901
 
             # If the right primer isn't "to the right" of the left primer, move on
             if rp.span.start < lp.span.start or lp.span.end > rp.span.end:
-                first_right_primer_idx = max(first_right_primer_idx, j+1)
+                first_right_primer_idx = max(first_right_primer_idx, j + 1)
                 continue
 
             amp_span = PrimerPair.calculate_amplicon_span(lp, rp)
 
             if amp_span.length < amplicon_sizes.min:
-                first_right_primer_idx = max(first_right_primer_idx, j+1)
+                first_right_primer_idx = max(first_right_primer_idx, j + 1)
                 continue
 
             if amp_span.length > amplicon_sizes.max:

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -232,7 +232,7 @@ class OffTargetDetector(AbstractContextManager):
                 and `max_amplicon_size` inclusive. If `allow_overlapping_hits` is False, primer
                 pair hits that overlap each other will not be considered, even if they would create
                 an amplicon of at least `min_amplicon_size`. Default 1bp.
-            allow_overlapping_hits: if True, allow hits to the invididual primers in a primer pair
+            allow_overlapping_hits: if True, allow hits to the individual primers in a primer pair
                 to overlap with each other. If False, no overlap will be allowed, even if
                 `min_amplicon_size` would otherwise allow it. Default False.
             cache_results: if True, cache results for faster re-querying

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -597,9 +597,9 @@ class OffTargetDetector(AbstractContextManager):
                 `positive_hits` are for the left primer and `negative_hits` are for the right
                 primer. Set to Strand.NEGATIVE if `positive_hits` are for the right primer and
                 `negative_hits` are for the left primer.
-            min_len: Minimum length of amplicons to consider. If `allow_overlap` is False, primer
-                pair hits that overlap each other will not be considered, even if they would create
-                an amplicon of at least `min_len`. Default 1bp.
+            min_len: Minimum length of amplicons to consider. If `allow_overlapping_hits` is False,
+                primer pair hits that overlap each other will not be considered, even if they would
+                create an amplicon of at least `min_len`. Default 1bp.
             allow_overlapping_hits: if True, allow hits to the individual primers in a primer pair
                 to overlap with each other. If False, no overlap will be allowed, even if
                 `min_amplicon_size` would otherwise allow it. Default False.

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -600,7 +600,7 @@ class OffTargetDetector(AbstractContextManager):
             min_len: Minimum length of amplicons to consider. If `allow_overlap` is False, primer
                 pair hits that overlap each other will not be considered, even if they would create
                 an amplicon of at least `min_len`. Default 1bp.
-            allow_overlapping_hits: if True, allow hits to the invididual primers in a primer pair
+            allow_overlapping_hits: if True, allow hits to the individual primers in a primer pair
                 to overlap with each other. If False, no overlap will be allowed, even if
                 `min_amplicon_size` would otherwise allow it. Default False.
 

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -238,6 +238,8 @@ class OffTargetDetector(AbstractContextManager):
 
         Raises:
             ValueError: If `max_amplicon_size` is not greater than 0.
+            ValueError: If `min_amplicon_size` is outside the range 1 to `max_amplicon_size`,
+                inclusive.
             ValueError: If any of `max_primer_hits`, `max_primer_pair_hits`, or
                 `min_primer_pair_hits` are not greater than or equal to 0.
             ValueError: If `three_prime_region_length` is not greater than or equal to 8.
@@ -250,6 +252,11 @@ class OffTargetDetector(AbstractContextManager):
         errors: list[str] = []
         if max_amplicon_size < 1:
             errors.append(f"'max_amplicon_size' must be greater than 0. Saw {max_amplicon_size}")
+        if min_amplicon_size < 1 or min_amplicon_size > max_amplicon_size:
+            errors.append(
+                f"'min_amplicon_size' must be between 1 and 'max_amplicon_size'={max_amplicon_size}"
+                f" inclusive. Saw {min_amplicon_size}"
+            )
         if max_primer_hits < 0:
             errors.append(
                 f"'max_primer_hits' must be greater than or equal to 0. Saw {max_primer_hits}"
@@ -317,33 +324,6 @@ class OffTargetDetector(AbstractContextManager):
         self._cache_results: bool = cache_results
         self._keep_spans: bool = keep_spans
         self._keep_primer_spans: bool = keep_primer_spans
-
-    def __post_init__(self) -> None:
-        """
-        Validates parameters.
-
-        Raises:
-            ValueError: If `min_amplicon_size` is greater than `max_amplicon_size`, or if either
-                value is less than 1.
-            ValueError: If `max_primer_hits`, `max_primer_pair_hits`, or `min_primer_pair_hits` are
-                less than 0.
-        """
-        errors: list[str] = []
-        if self._min_amplicon_size < 1:
-            errors.append("'min_amplicon_size' must be greater than or equal to 1.")
-        if self._max_amplicon_size < 1:
-            errors.append("'max_amplicon_size' must be greater than or equal to 1.")
-        if self._min_amplicon_size > self._max_amplicon_size:
-            errors.append("'min_amplicon_size' must be less than or equal to 'max_amplicon_size'.")
-        if self._max_primer_hits < 0:
-            errors.append("'max_primer_hits' must be greater than or equal to 0.")
-        if self._max_primer_pair_hits < 0:
-            errors.append("'max_primer_pair_hits' must be greater than or equal to 0.")
-        if self._min_primer_pair_hits < 0:
-            errors.append("'min_primer_pair_hits' must be greater than or equal to 0.")
-
-        if len(errors) > 0:
-            raise ValueError("\n".join(errors))
 
     def filter(self, primers: list[PrimerType]) -> list[PrimerType]:
         """

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -631,8 +631,6 @@ class OffTargetDetector(AbstractContextManager):
 
         amplicons: list[Span] = []
 
-        print(min_len, max_len)
-
         # Track the position of the previously examined negative hit.
         prev_negative_hit_index = 0
         for positive_hit in positive_hits_sorted:
@@ -641,6 +639,7 @@ class OffTargetDetector(AbstractContextManager):
                 negative_hits_sorted[prev_negative_hit_index:],
                 start=prev_negative_hit_index,
             ):
+                # Hit coordinates are 1-based end-inclusive.
                 amplicon_length: int = negative_hit.end - positive_hit.start + 1
                 if min_len <= amplicon_length <= max_len:
                     # If the negative hit starts to the right of the positive hit, and the amplicon

--- a/prymer/offtarget/offtarget_detector.py
+++ b/prymer/offtarget/offtarget_detector.py
@@ -40,7 +40,7 @@ the off-target mappings.
 OffTargetResult(primer_pair=..., passes=False, cached=False, spans=[], left_primer_spans=[], right_primer_spans=[])
 >>> list(detector.check_all(primer_pairs=[primer_pair]).values())
 [OffTargetResult(primer_pair=..., passes=False, cached=True, spans=[], left_primer_spans=[], right_primer_spans=[])]
->>> detector = OffTargetDetector(ref=ref_fasta, max_primer_hits=204, max_primer_pair_hits=856, three_prime_region_length=20, max_mismatches_in_three_prime_region=0, max_mismatches=0, max_amplicon_size=250)
+>>> detector = OffTargetDetector(ref=ref_fasta, max_primer_hits=204, max_primer_pair_hits=856, three_prime_region_length=20, max_mismatches_in_three_prime_region=0, max_mismatches=0, min_amplicon_size=10, max_amplicon_size=250)
 >>> result = detector.check_one(primer_pair=primer_pair)
 >>> len(result.spans)
 856

--- a/tests/offtarget/test_offtarget.py
+++ b/tests/offtarget/test_offtarget.py
@@ -24,8 +24,9 @@ def _build_detector(
     three_prime_region_length: int = 20,
     max_mismatches_in_three_prime_region: int = 0,
     max_mismatches: int = 0,
-    min_amplicon_size: int = 10,
+    min_amplicon_size: int = 1,
     max_amplicon_size: int = 250,
+    allow_overlapping_hits: bool = False,
     cache_results: bool = True,
 ) -> OffTargetDetector:
     """Builds an `OffTargetDetector` with strict defaults"""
@@ -38,6 +39,7 @@ def _build_detector(
         max_mismatches=max_mismatches,
         min_amplicon_size=min_amplicon_size,
         max_amplicon_size=max_amplicon_size,
+        allow_overlapping_hits=allow_overlapping_hits,
         cache_results=cache_results,
         keep_spans=True,
         keep_primer_spans=True,
@@ -350,6 +352,7 @@ def test_to_amplicons_overlapping(
             negative_hits=[negative],
             min_len=1,
             max_len=250,
+            allow_overlapping_hits=True,
             strand=strand,
         )
         assert actual == expected, test_id

--- a/tests/offtarget/test_offtarget.py
+++ b/tests/offtarget/test_offtarget.py
@@ -24,6 +24,7 @@ def _build_detector(
     three_prime_region_length: int = 20,
     max_mismatches_in_three_prime_region: int = 0,
     max_mismatches: int = 0,
+    min_amplicon_size: int = 10,
     max_amplicon_size: int = 250,
     cache_results: bool = True,
 ) -> OffTargetDetector:
@@ -35,6 +36,7 @@ def _build_detector(
         three_prime_region_length=three_prime_region_length,
         max_mismatches_in_three_prime_region=max_mismatches_in_three_prime_region,
         max_mismatches=max_mismatches,
+        min_amplicon_size=min_amplicon_size,
         max_amplicon_size=max_amplicon_size,
         cache_results=cache_results,
         keep_spans=True,
@@ -281,7 +283,11 @@ def test_to_amplicons(
 ) -> None:
     with _build_detector(ref_fasta=ref_fasta, cache_results=cache_results) as detector:
         actual = detector._to_amplicons(
-            positive_hits=[positive], negative_hits=[negative], max_len=250, strand=strand
+            positive_hits=[positive],
+            negative_hits=[negative],
+            min_len=200,
+            max_len=250,
+            strand=strand,
         )
         assert actual == expected, test_id
 
@@ -322,7 +328,11 @@ def test_to_amplicons_value_error(
         pytest.raises(ValueError, match=expected_error),
     ):
         detector._to_amplicons(
-            positive_hits=[positive], negative_hits=[negative], max_len=250, strand=Strand.POSITIVE
+            positive_hits=[positive],
+            negative_hits=[negative],
+            min_len=200,
+            max_len=250,
+            strand=Strand.POSITIVE,
         )
 
 

--- a/tests/offtarget/test_offtarget.py
+++ b/tests/offtarget/test_offtarget.py
@@ -429,20 +429,22 @@ def test_generic_filter(ref_fasta: Path) -> None:
 @pytest.mark.parametrize(
     (
         "max_primer_hits,max_primer_pair_hits,min_primer_pair_hits,three_prime_region_length,"
-        "max_mismatches_in_three_prime_region,max_mismatches,max_amplicon_size,"
+        "max_mismatches_in_three_prime_region,max_mismatches,max_amplicon_size,min_amplicon_size,"
         "max_gap_opens,max_gap_extends,expected_error"
     ),
     [
-        (-1, 1, 1, 20, 0, 0, 1, 0, 0, "'max_primer_hits' must be greater than or equal to 0. Saw -1"),  # noqa: E501
-        (1, -1, 1, 20, 0, 0, 1, 0, 0, "'max_primer_pair_hits' must be greater than or equal to 0. Saw -1"),  # noqa: E501
-        (1, 1, -1, 20, 0, 0, 1, 0, 0, "'min_primer_pair_hits' must be greater than or equal to 0. Saw -1"),  # noqa: E501
-        (1, 1, 1, 5, 0, 0, 1, 0, 0, "'three_prime_region_length' must be greater than or equal to 8. Saw 5"),  # noqa: E501
-        (1, 1, 1, 20, -1, 0, 1, 0, 0, "'max_mismatches_in_three_prime_region' must be between 0 and 'three_prime_region_length'=20 inclusive. Saw -1"),  # noqa: E501
-        (1, 1, 1, 20, 21, 0, 1, 0, 0, "'max_mismatches_in_three_prime_region' must be between 0 and 'three_prime_region_length'=20 inclusive. Saw 21"),  # noqa: E501
-        (1, 1, 1, 20, 0, -1, 1, 0, 0, "'max_mismatches' must be greater than or equal to 0. Saw -1"),  # noqa: E501
-        (1, 1, 1, 20, 0, 0, 0, 0, 0, "'max_amplicon_size' must be greater than 0. Saw 0"),
-        (1, 1, 1, 20, 0, 0, 1, -1, 0, "'max_gap_opens' must be greater than or equal to 0. Saw -1"),
-        (1, 1, 1, 20, 0, 5, 1, 0, -2, re.escape("'max_gap_extends' must be -1 (for unlimited extensions up to 'max_mismatches'=5) or greater than or equal to 0. Saw -2")), #noqa: E501
+        (-1, 1, 1, 20, 0, 0, 1, 1, 0, 0, "'max_primer_hits' must be greater than or equal to 0. Saw -1"),  # noqa: E501
+        (1, -1, 1, 20, 0, 0, 1, 1, 0, 0, "'max_primer_pair_hits' must be greater than or equal to 0. Saw -1"),  # noqa: E501
+        (1, 1, -1, 20, 0, 0, 1, 1, 0, 0, "'min_primer_pair_hits' must be greater than or equal to 0. Saw -1"),  # noqa: E501
+        (1, 1, 1, 5, 0, 0, 1, 1, 0, 0, "'three_prime_region_length' must be greater than or equal to 8. Saw 5"),  # noqa: E501
+        (1, 1, 1, 20, -1, 0, 1, 1, 0, 0, "'max_mismatches_in_three_prime_region' must be between 0 and 'three_prime_region_length'=20 inclusive. Saw -1"),  # noqa: E501
+        (1, 1, 1, 20, 21, 0, 1, 1, 0, 0, "'max_mismatches_in_three_prime_region' must be between 0 and 'three_prime_region_length'=20 inclusive. Saw 21"),  # noqa: E501
+        (1, 1, 1, 20, 0, -1, 1, 1, 0, 0, "'max_mismatches' must be greater than or equal to 0. Saw -1"),  # noqa: E501
+        (1, 1, 1, 20, 0, 0, 0, 1, 0, 0, "'max_amplicon_size' must be greater than 0. Saw 0"),
+        (1, 1, 1, 20, 0, 0, 1, 1, -1, 0, "'max_gap_opens' must be greater than or equal to 0. Saw -1"), # noqa: E501
+        (1, 1, 1, 20, 0, 5, 1, 1, 0, -2, re.escape("'max_gap_extends' must be -1 (for unlimited extensions up to 'max_mismatches'=5) or greater than or equal to 0. Saw -2")), #noqa: E501
+        (1, 1, 1, 20, 0, 0, 10, 0, 0, 0, "'min_amplicon_size' must be between 1 and 'max_amplicon_size'=10 inclusive. Saw 0"),  # noqa: E501
+        (1, 1, 1, 20, 0, 0, 10, 11, 0, 0, "'min_amplicon_size' must be between 1 and 'max_amplicon_size'=10 inclusive. Saw 11"),  # noqa: E501
     ],
 )
 # fmt: on
@@ -455,6 +457,7 @@ def test_init(
     max_mismatches_in_three_prime_region: int,
     max_mismatches: int,
     max_amplicon_size: int,
+    min_amplicon_size: int,
     max_gap_opens: int,
     max_gap_extends: int,
     expected_error: str,
@@ -469,6 +472,7 @@ def test_init(
             max_mismatches_in_three_prime_region=max_mismatches_in_three_prime_region,
             max_mismatches=max_mismatches,
             max_amplicon_size=max_amplicon_size,
+            min_amplicon_size=min_amplicon_size,
             max_gap_opens=max_gap_opens,
             max_gap_extends=max_gap_extends,
         )


### PR DESCRIPTION
See [discussion](https://github.com/fulcrumgenomics/prymer/pull/99#discussion_r1884336606).

The code before this PR does not return primer pair hits where the hits to the left and right primers overlap, and does not specify a minimum acceptable amplicon size.

This change adds two new parameters to the `OffTargetDetector` to address this:
* `allow_overlapping_hits` - defaults to `False` to maintain current behaviour. If this is set to `True`, then primer pair hits where the left and right primer hits overlap are allowed, as long as they meet the acceptable amplicon size criteria.
* `min_amplicon_size` - defaults to `1` to maintain current behaviour, and is overridden by `allow_overlapping_hits=False`.