### PR TITLE
chore: Add verbose retry when installing dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install the project's dependencies
         shell: bash -el {0}
-        run: poetry install
+        run: poetry install -v || poetry install -vv
 
       - name: Test the codebase
         shell: bash -el {0}


### PR DESCRIPTION
## Summary

If `poetry install` fails in the test run, try again with increased verbosity.

The retry may resolve transient errors, and if it doesn't, we get a more detailed error log.